### PR TITLE
bug : changing order of resourceType

### DIFF
--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -184,9 +184,9 @@ export default (token: string, baseURL: string): API => {
 			name: string,
 			env: string[],
 			plan: string,
+			resourceType: ResourceType,
 			release: string = Date.now().toString(16),
-			version = 'v1',
-			resourceType: ResourceType
+			version = 'v1'
 		): Promise<string> =>
 			axios
 				.post<string>(


### PR DESCRIPTION
### Description
Changed order of ```resourceType``` parameter because the endpoint is used like this (see below) on CLI and it is throwing errors as we are trying to pass ```ResourceType``` to type string.

Implementation In Deploy CLI.

```js
await api.deploy(response.id, [], plan, 'Repository');
```

you can see ```Repository``` is being passed to ```release```.