### PR TITLE
corrected env argument signature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "@metacall/protocol",
 			"version": "0.1.17",
+			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@types/ignore-walk": "^4.0.0",

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -67,7 +67,7 @@ interface API {
 	): Promise<AddResponse>;
 	deploy(
 		name: string,
-		env: string[],
+		env: { name: string; value: string }[],
 		plan: Plans,
 		resourceType: ResourceType,
 		release?: string,
@@ -210,7 +210,7 @@ export default (token: string, baseURL: string): API => {
 
 		deploy: (
 			name: string,
-			env: string[],
+			env: { name: string; value: string }[],
 			plan: Plans,
 			resourceType: ResourceType,
 			release: string = Date.now().toString(16),


### PR DESCRIPTION
In deploy() function, an argument named "env" had wrong signature (string[]), corrected that.