### PR TITLE
fix: frontend compability

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
 			"*": [
 				"dist/*.d.ts"
 			],
-			".": [
-				"dist/index.d.ts"
-			]
+			".": ["./dist/index.d.ts"]
 		}
 	},
 	"scripts": {
@@ -94,7 +92,8 @@
 	},
 	"devDependencies": {
 		"@types/express": "^4.17.13",
-		"@types/mocha": "^8.2.2",
+		"@types/jest": "^29.5.2",
+		"@types/mocha": "^8.2.3",
 		"@types/node": "^14.14.7",
 		"@types/swagger-ui-express": "^4.1.3",
 		"@types/yamljs": "^0.2.31",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,16 @@
 	"description": "Tool for deploying into MetaCall FaaS platform.",
 	"exports": {
 		"./*": "./dist/*.js",
+		".": "./dist/index.js",
 		"./package.json": "./package.json"
 	},
 	"typesVersions": {
 		"*": {
 			"*": [
 				"dist/*.d.ts"
+			],
+			".": [
+				"dist/index.d.ts"
 			]
 		}
 	},

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,9 @@
+export * from './deployment'
+export * from './language'
+export * from './login'
+export * from './package'
+export * from './plan'
+export * from './token'
+import metacallAPI from './protocol'
+export * from './protocol'
+export default metacallAPI

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -37,7 +37,10 @@ export interface SubscriptionDeploy {
 	deploy: string;
 }
 
-export type ResourceType = 'Package' | 'Repository';
+export enum ResourceType {
+	Package = 'Package',
+	Repository = 'Repository'
+};
 
 export interface AddResponse {
 	id: string;
@@ -57,8 +60,8 @@ export interface API {
 	upload(
 		name: string,
 		blob: unknown,
-		jsons: MetaCallJSON[],
-		runners: string[]
+		jsons?: MetaCallJSON[],
+		runners?: string[]
 	): Promise<string>;
 	add(
 		url: string,
@@ -171,7 +174,7 @@ export default (token: string, baseURL: string): API => {
 				{
 					headers: {
 						Authorization: 'jwt ' + token,
-						...fd.getHeaders()
+						...(fd.getHeaders?.() ?? {}) // operator chaining to make it compatible with frontend
 					}
 				}
 			);


### PR DESCRIPTION
This pull request makes protocol library to be used with frontend lib/framework.

changes:-
 - added index.js to get necessary types and functions without importing different files for each use cases
- exported ResourceType as enum instead of type so that it can be used 
- fd.getHeaders is not available when form-data library is used in frontend, so patched it to be usable by frontend
