### PR TITLE
fix(protocol): remove Node.js-specific URL import for frontend compatibility

### DIFF
--- a/src/login.ts
+++ b/src/login.ts
@@ -1,4 +1,3 @@
-import { URL } from 'url';
 import { ProtocolError } from './protocol';
 
 interface Request {
@@ -21,11 +20,15 @@ export default async (
 		request['g-recaptcha-response'] = 'empty'; // TODO: Review the captcha
 	}
 
+	// Use built-in URL class (available in both browsers and Node.js 10+)
+	// No need to import from 'url' module which is Node.js-specific
+	const url = new URL(baseURL);
+
 	const res = await fetch(baseURL + '/login', {
 		method: 'POST',
 		headers: {
 			Accept: 'application/json, text/plain, */*',
-			Host: new URL(baseURL).host,
+			Host: url.host,
 			Origin: baseURL,
 			'Content-Type': 'application/json'
 		},


### PR DESCRIPTION
## Description

The login module was importing `URL` from Node.js `'url'` module, which is not available in browser environments. This prevented the protocol package from being imported in frontend applications.

Fixes #32

## Changes
- Remove `import { URL } from 'url'` (Node.js-specific)
- Use built-in `URL` class (available in browsers and Node.js 10+)
- No functional changes, just import compatibility

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Build passes (`npm run build`)
- [x] Lint passes (`npm run lint`)